### PR TITLE
warn (don't just fail) if no license found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ set(MOSEK_PLATFORM_PATH "${CMAKE_CURRENT_BINARY_DIR}/mosek/7/tools/platform/${PL
 
 # Check for the mosek license file
 if (NOT EXISTS $ENV{HOME}/mosek/mosek.lic)
-    message(FATAL_ERROR "You do not appear to have a license for mosek installed in $ENV{HOME}/mosek/mosek.lic\n If you are an academic user, you can open the following url in your favorite browser and request the license:\n     http://license.mosek.com/license2/academic/\n Then check your email for the license file and put it in $ENV{HOME}/mosek/mosek.lic\n Otherwise visit https://mosek.com/resources/trial-license to request a trial license.")
+    message(WARNING "You do not appear to have a license for mosek installed in $ENV{HOME}/mosek/mosek.lic\n If you are an academic user, you can open the following url in your favorite browser and request the license:\n     http://license.mosek.com/license2/academic/\n Then check your email for the license file and put it in $ENV{HOME}/mosek/mosek.lic\n Otherwise visit https://mosek.com/resources/trial-license to request a trial license.")
 endif()
 
 # Download and unzip the source


### PR DESCRIPTION
Throwing an error here kills the entire build, which is overly dramatic. It also might cause a difficult-to-find error in the middle of a parallel build. 

Mosek already prints helpful errors and instructions when you try to use it without a license.